### PR TITLE
Upgrade ORT to v1.15

### DIFF
--- a/guru-android-sdk/build.gradle
+++ b/guru-android-sdk/build.gradle
@@ -63,7 +63,7 @@ dependencies {
 }
 
 task installNativeLibs(type: InstallNativeLibsTask) {
-    onnxUrl = "https://repo1.maven.org/maven2/com/microsoft/onnxruntime/onnxruntime-android/1.15.0/onnxruntime-android-1.15.0.aar"
+    onnxUrl = "https://repo1.maven.org/maven2/com/microsoft/onnxruntime/onnxruntime-android/1.15.1/onnxruntime-android-1.15.1.aar"
     openCvUrl = "https://github.com/opencv/opencv/releases/download/4.7.0/opencv-4.7.0-android-sdk.zip"
     destDir = "${project.projectDir}/src/main/jni"
 }

--- a/guru-android-sdk/build.gradle
+++ b/guru-android-sdk/build.gradle
@@ -63,7 +63,7 @@ dependencies {
 }
 
 task installNativeLibs(type: InstallNativeLibsTask) {
-    onnxUrl = "https://repo1.maven.org/maven2/com/microsoft/onnxruntime/onnxruntime-android/1.14.0/onnxruntime-android-1.14.0.aar"
+    onnxUrl = "https://repo1.maven.org/maven2/com/microsoft/onnxruntime/onnxruntime-android/1.15.0/onnxruntime-android-1.15.0.aar"
     openCvUrl = "https://github.com/opencv/opencv/releases/download/4.7.0/opencv-4.7.0-android-sdk.zip"
     destDir = "${project.projectDir}/src/main/jni"
 }


### PR DESCRIPTION
Use the latest version of the onnxruntime, which both supports the latest ONNX opset version and is backwards compatible with older versions.